### PR TITLE
Fix: jimowang.com 正则匹配格式错误

### DIFF
--- a/tools/uBlacklist_backup.txt
+++ b/tools/uBlacklist_backup.txt
@@ -64369,7 +64369,7 @@ https://vimsky.com/zh-tw/examples/detail/python-method-tempfile.mkstemp.html
 ####################
 ### Content Farm ###
 ####################
-*:/*.jimowang.com/*
+*://*.jimowang.com/*
 *://*.0757it.cn/*
 *://*.105188.com/*
 *://*.111cn.net/*

--- a/uBlacklist.txt
+++ b/uBlacklist.txt
@@ -1,6 +1,6 @@
 ! Update weekly at 2024-11-03 08:46:10 +0800
 
-*:/*.jimowang.com/*
+*://*.jimowang.com/*
 *://*..sailaila.net/*
 *://*.001553.cn/*
 *://*.003zuqiu.com/*


### PR DESCRIPTION
在匹配列表中发现 `jimowang.com` 的正则格式为 `*:/*.jimowang.com/*`，这似乎存在问题，遂修改为 `*://*.jimowang.com/*`。经过本机测试，前者不能正确发挥屏蔽作用，而后者可以。